### PR TITLE
Test generation of reader on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,42 @@
+sudo: false
+
 language: python
 
 python:
   - 3.3
   - 3.4
 
+addons:
+  apt:
+    packages:
+      - texlive-xetex
+      - texlive-latex-recommended
+      - lmodern
+      - texlive-latex-extra
+      - texlive-lang-greek
+      - fonts-linuxlibertine
+
 install:
   - pip install flake8
+  - pip install -r requirements.txt
+  - mkdir ci.deps
+  - curl -o ci.deps/lexemes.yaml https://raw.githubusercontent.com/morphgnt/morphological-lexicon/4e3dbfd872bc12d11d8949be98e4f72dfc0ea9f0/lexemes.yaml
+
+before_script:
+  - flake8 .
+  - fc-list
+  - mkdir ci.out
 
 script:
-  - flake8 .
+  - ./frequency_exclusion.py 31 > ci.out/exclude.txt
+  - ./make_glosses.py --exclude ci.out/exclude.txt --lexicon ci.deps/lexemes.yaml "John 18:1-11" > ci.out/glosses.yaml
+  - ./make_headwords.py --exclude ci.out/exclude.txt --lexicon ci.deps/lexemes.yaml "John 18:1-11" > ci.out/headwords.yaml
+  - ./reader.py --headwords ci.out/headwords.yaml --glosses ci.out/glosses.yaml --exclude ci.out/exclude.txt --typeface "Linux Libertine O" "John 18:1-11" --backend backends.LaTeX > ci.out/reader.tex
+  - cd ci.out
+  - xelatex reader.tex
+  - xelatex reader.tex
+  - cd ..
+  - ls -l ci.out/reader.pdf
+
+after_success:
+  - md5sum ci.out/reader.pdf

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
       - texlive-latex-extra
       - texlive-lang-greek
       - fonts-linuxlibertine
+      - poppler-utils
 
 install:
   - pip install flake8
@@ -39,4 +40,5 @@ script:
   - ls -l ci.out/reader.pdf
 
 after_success:
-  - md5sum ci.out/reader.pdf
+  - file ci.out/reader.pdf
+  - pdftotext ci.out/reader.pdf - # http://stackoverflow.com/questions/6187250/pdf-text-extraction/6189489#6189489

--- a/make_glosses.py
+++ b/make_glosses.py
@@ -42,7 +42,7 @@ for entry in get_morphgnt(verses):
     if entry[0] == "WORD":
         lemma = entry[1]["lemma"]
         if lemma not in exclusions and lemma not in glosses:
-            glosses[lemma] = {"default": lexemes[lemma].get("gloss", "@@@")}
+            glosses[lemma] = {"default": lexemes[lemma].get("gloss", "\"@@@\"")}
 
 for lemma, gloss_entries in sorted_items(glosses):
     print("{}:".format(lemma))

--- a/make_headwords.py
+++ b/make_headwords.py
@@ -15,9 +15,6 @@ argparser.add_argument(
     default="../morphological-lexicon/lexemes.yaml",
     help="path to morphological-lexicon lexemes.yaml file "
     "(defaults to ../morphological-lexicon/lexemes.yaml)")
-argparser.add_argument(
-    "--sblgnt", dest="sblgnt_dir", default="../sblgnt",
-    help="path to MorphGNT sblgnt directory (defaults to ../sblgnt)")
 
 args = argparser.parse_args()
 
@@ -36,17 +33,17 @@ else:
     headwords = {}
 
 
-for entry in get_morphgnt(verses, args.sblgnt_dir):
+for entry in get_morphgnt(verses):
     if entry[0] == "WORD":
-        lexeme = entry[8]
-        if lexeme not in exclusions and lexeme not in headwords:
-            pos = entry[2]
+        lemma = entry[1]["lemma"]
+        if lemma not in exclusions and lemma not in headwords:
+            pos = entry[1]["ccat-pos"]
             if pos in ["N-", "A-"]:
-                if "full-citation-form" in lexemes[lexeme]:
-                    headword = lexemes[lexeme]["full-citation-form"]
+                if "full-citation-form" in lexemes[lemma]:
+                    headword = lexemes[lemma]["full-citation-form"]
                 else:
-                    headword = lexemes[lexeme]["danker-entry"]
-                headwords[lexeme] = headword
+                    headword = lexemes[lemma]["danker-entry"]
+                headwords[lemma] = headword
 
-for lexeme, headword in sorted_items(headwords):
-    print("{}: {}".format(lexeme, headword))
+for lemma, headword in sorted_items(headwords):
+    print("{}: {}".format(lemma, headword))


### PR DESCRIPTION
Depends on #11.

Notes:
* I based most of my development on PR #9 (acfd6b7) but I understand that it does not matter - especially since I avoided using `--language`;
* I kept only one job (per Python version), in particular:
  * I moved `flake8` to `before_script` (seen [here](http://eldarion.com/blog/2014/06/03/how-we-work-continuous-integration/));
  * I did not prepare an easy way for adding test of other backend in PR #9 as separate job.
* I took arbitrary decisions in splitting `install`/`before_script`/`script`/`after_success` - feel free to re-arrange of course - and in font;
* The verse reference shall probably be factored out.

You can inspect the generated PDF adding the following snippet at the end of `after_success`:
```
  - md5sum ci.out/reader.pdf
  - B=ci.out/reader.pdf; U=$(cat $B | openssl base64 | curl -F 'sprunge=<-' 'http://sprunge.us') && echo "HINT curl $U | openssl base64 -d > $(basename $B)"
```
... but I would **not** recommend adding this snippet to master - or all PRs would trigger it.

BTW Would you agree that:
* From time to time tags could be taken;
* When taking a tag, `reader.pdf` (at least from one of the backends) shall be uploaded back to GitHub (I think it is possible with Travis CI).
I mention this because the PDF in the `example` directory looks slightly different from what I got - especially in the glosses - maybe because that file was generated some time ago plus a couple of glosses were manually enriched?