### PR TITLE
Make glosses and headwords for the whole NT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
 
 script:
   - ./frequency_exclusion.py 31 > ci.out/exclude.txt
+  - echo "μήν" >> ci.out/exclude.txt # `μήν/N` (noun, strong 3376, gloss "a month") or `μήν/X` (particle, strong 3375, gloss "certainly")? Ref https://github.com/morphgnt/morphological-lexicon/commit/0c96a74f08381933f1de21457cc7d13f1aa5654e#diff-2d41209e747bb484493248c8f3f2158f
   - ./make_glosses.py --exclude ci.out/exclude.txt --lexicon ci.deps/lexemes.yaml "$VERSES" > ci.out/glosses.yaml
   - ./make_headwords.py --exclude ci.out/exclude.txt --lexicon ci.deps/lexemes.yaml "$VERSES" > ci.out/headwords.yaml
   - ./reader.py --headwords ci.out/headwords.yaml --glosses ci.out/glosses.yaml --language eng --exclude ci.out/exclude.txt --typeface "Linux Libertine O" "$VERSES" --backend backends.$BACKEND | build_reader_$BACKEND ci.out reader

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ before_script:
 script:
   - ./frequency_exclusion.py 31 > ci.out/exclude.txt
   - echo "μήν" >> ci.out/exclude.txt # `μήν/N` (noun, strong 3376, gloss "a month") or `μήν/X` (particle, strong 3375, gloss "certainly")? Ref https://github.com/morphgnt/morphological-lexicon/commit/0c96a74f08381933f1de21457cc7d13f1aa5654e#diff-2d41209e747bb484493248c8f3f2158f
+  - echo "καταβιβάζω" >> ci.out/exclude.txt # καταβιβάζω (strong 2601) missing from lexemes.yaml
+  - echo "ὑπερβαίνω" >> ci.out/exclude.txt # ὑπερβαίνω (strong 5233) missing from lexemes.yaml
   - ./make_glosses.py --exclude ci.out/exclude.txt --lexicon ci.deps/lexemes.yaml "$VERSES" > ci.out/glosses.yaml
   - ./make_headwords.py --exclude ci.out/exclude.txt --lexicon ci.deps/lexemes.yaml "$VERSES" > ci.out/headwords.yaml
   - ./reader.py --headwords ci.out/headwords.yaml --glosses ci.out/glosses.yaml --language eng --exclude ci.out/exclude.txt --typeface "Linux Libertine O" "$VERSES" --backend backends.$BACKEND | build_reader_$BACKEND ci.out reader

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
   - echo "μήν" >> ci.out/exclude.txt # `μήν/N` (noun, strong 3376, gloss "a month") or `μήν/X` (particle, strong 3375, gloss "certainly")? Ref https://github.com/morphgnt/morphological-lexicon/commit/0c96a74f08381933f1de21457cc7d13f1aa5654e#diff-2d41209e747bb484493248c8f3f2158f
   - echo "καταβιβάζω" >> ci.out/exclude.txt # καταβιβάζω (strong 2601) missing from lexemes.yaml
   - echo "ὑπερβαίνω" >> ci.out/exclude.txt # ὑπερβαίνω (strong 5233) missing from lexemes.yaml
+  - echo "πυκνά" >> ci.out/exclude.txt # πυκνά (strong 4437) without headwords in lexemes.yaml
   - ./make_glosses.py --exclude ci.out/exclude.txt --lexicon ci.deps/lexemes.yaml "$VERSES" > ci.out/glosses.yaml
   - ./make_headwords.py --exclude ci.out/exclude.txt --lexicon ci.deps/lexemes.yaml "$VERSES" > ci.out/headwords.yaml
   - ./reader.py --headwords ci.out/headwords.yaml --glosses ci.out/glosses.yaml --language eng --exclude ci.out/exclude.txt --typeface "Linux Libertine O" "$VERSES" --backend backends.$BACKEND | build_reader_$BACKEND ci.out reader


### PR DESCRIPTION
Excluding 4 lemmas enables making glosses and headwords for the whole NT. Please refer to comments in `.travis.yml` for details.

* μήν looks too hard to solve;
* καταβιβάζω looks related to [ref](https://github.com/morphgnt/sblgnt/commit/50ad3d2949457b5cf6003ceca516b42e4dcd463b) - maybe lexemes.yaml needs update?
* ὑπερβαίνω looks related to [ref](https://github.com/morphgnt/sblgnt/commit/13db1a37d85d7c38de2df1fdba9d767c4325e737) - maybe lexemes.yaml needs update?
* πυκνά - wrong lemma in 030533? (πυκνά vs. πυκνός)

I am not sure how to improve morphgnt or lexemes.yaml in order not to avoid these lemmas from the reader. Input on location of files to use in order to populate lexemes.yaml (e.g. is [source for strong numbers](https://raw.githubusercontent.com/morphgnt/strongs-dictionary-xml/master/strongsgreek.xml) ok?) is welcome.

----

BTW current failure in building reader for whole NT is the following:
```
$ ./reader.py --headwords ci.out/headwords.yaml --glosses ci.out/glosses.yaml --language eng --exclude ci.out/exclude.txt --typeface "Linux Libertine O" "$VERSES" --backend backends.$BACKEND | build_reader_$BACKEND ci.out reader
...
(/usr/share/texmf-texlive/tex/xelatex/polyglossia/gloss-english.ldf)
No file reader.aux.
Underfull \hbox (badness 5726) in paragraph at lines 4779--4779
 [] [][]\EU1/LinuxLibertineO(2)/m/n/10 ἐνθύμησις, εως, ἡ \OT1/Li
nuxLibertineO(2)/m/n/10 { []\EU1/LinuxLibertineO(0)/m/it/10 inward thought, ref
lection,
Underfull \hbox (badness 5726) in paragraph at lines 7222--7222
 [] [][]\EU1/LinuxLibertineO(2)/m/n/10 ἐνθύμησις, εως, ἡ \OT1/Li
nuxLibertineO(2)/m/n/10 { []\EU1/LinuxLibertineO(0)/m/it/10 inward thought, ref
lection,
Overfull \vbox (16392.16035pt too high) detected at line 19588
! Dimension too large.
<argument> \dfn@boxa 
                     
l.19588 ...\ \textenglish{\textit{I mix, mingle}}}
                                                  
? 
! Emergency stop.
<argument> \dfn@boxa 
                     
l.19588 ...\ \textenglish{\textit{I mix, mingle}}}
                                                  
No pages of output.
Transcript written on reader.log.
The command "./reader.py --headwords ci.out/headwords.yaml --glosses ci.out/glosses.yaml --language eng --exclude ci.out/exclude.txt --typeface "Linux Libertine O" "$VERSES" --backend backends.$BACKEND | build_reader_$BACKEND ci.out reader" exited with 1.
```