### PR TITLE
Move footnotes in LaTeX from double- to single-columned

### DIFF
--- a/backends.py
+++ b/backends.py
@@ -15,7 +15,6 @@ class LaTeX:
 
 \\usepackage{{setspace}}
 \\usepackage{{fontspec}}
-\\usepackage{{dblfnote}}
 \\usepackage{{pfnote}}
 \\usepackage{{polyglossia}}
 \\setdefaultlanguage[variant=ancient]{{greek}}


### PR DESCRIPTION
Please refer to commit message for details.

I am aware this is only a workaround (good enough in my opinion) - a more elegant solution might be possible in order to keep double-columned footnotes. LaTeX expert required.
