### PR TITLE
Test exclusions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ before_script:
   - mkdir ci.out
 
 script:
-  - ./frequency_exclusion.py 31 > ci.out/exclude.txt
+  - ./frequency_exclusion.py $LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE > ci.out/exclude.txt
+  - wc -l ci.out/exclude.txt
   - ./make_glosses.py --exclude ci.out/exclude.txt --lexicon ci.deps/lexemes.yaml "$VERSES" > ci.out/glosses.yaml
   - ./make_headwords.py --exclude ci.out/exclude.txt --lexicon ci.deps/lexemes.yaml "$VERSES" > ci.out/headwords.yaml
   - ./reader.py --headwords ci.out/headwords.yaml --glosses ci.out/glosses.yaml --language eng --exclude ci.out/exclude.txt --typeface "Linux Libertine O" "$VERSES" --backend backends.$BACKEND | build_reader_$BACKEND ci.out reader
@@ -48,12 +49,19 @@ after_success:
   - describe_reader_file_$BACKEND ci.out/$RF
 
 env:
-  - BACKEND=LaTeX VERSES="John 18:1-11"
-  - BACKEND=SILE VERSES="John 18:1-11"
-  - BACKEND=LaTeX VERSES="Matthew 1:1-Revelation 22:21"
+  - BACKEND=LaTeX VERSES="John 18:1-11" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=31
+  - BACKEND=LaTeX VERSES="John 18:1-11" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=48
+  - BACKEND=LaTeX VERSES="John 18:1-11" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=662
+  - BACKEND=LaTeX VERSES="John 18:1-11" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=1000000
+  - BACKEND=SILE VERSES="John 18:1-11" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=31
+  - BACKEND=LaTeX VERSES="Matthew 1:1-Revelation 22:21" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=31
+  - BACKEND=LaTeX VERSES="Matthew 1:1-Revelation 22:21" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=48
+  - BACKEND=LaTeX VERSES="Matthew 1:1-Revelation 22:21" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=190
 
 matrix:
   allow_failures:
-    - env: BACKEND=SILE VERSES="John 18:1-11"
-    - env: BACKEND=LaTeX VERSES="Matthew 1:1-Revelation 22:21"
+    - env: BACKEND=SILE VERSES="John 18:1-11" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=31
+    - env: BACKEND=LaTeX VERSES="Matthew 1:1-Revelation 22:21" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=31
+    - env: BACKEND=LaTeX VERSES="Matthew 1:1-Revelation 22:21" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=48
+    - env: BACKEND=LaTeX VERSES="Matthew 1:1-Revelation 22:21" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=190
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - curl -o ci.deps/lexemes.yaml https://raw.githubusercontent.com/morphgnt/morphological-lexicon/4e3dbfd872bc12d11d8949be98e4f72dfc0ea9f0/lexemes.yaml
 
 before_script:
-  - describe_pdf_file() { pdftotext "${1:?}" -; } # http://stackoverflow.com/questions/6187250/pdf-text-extraction/6189489#6189489
+  - describe_pdf_file() { pdftotext "${1:?}" - | tail; } # http://stackoverflow.com/questions/6187250/pdf-text-extraction/6189489#6189489
   - build_reader_LaTeX() { local D="${1:?}"; local T="${2:?}.tex"; cat - > "${D}/$T"; cd "$D"; xelatex "$T" && xelatex "$T" || exit 1; }
   - reader_filename_LaTeX() { echo "${1:?}.pdf"; }
   - describe_reader_file_LaTeX() { describe_pdf_file "${1:?}"; }

--- a/backends.py
+++ b/backends.py
@@ -34,7 +34,8 @@ class LaTeX:
 """.format(typeface=typeface, language=self.lang_code(language))
 
     def book_chapter_verse(self, book, chapter, verse):
-        return "\\textbf{{\Large {}.{}.{}}}~".format(book, chapter, verse)
+        return """
+\\textbf{{\Large {}.{}.{}}}~""".format(book, chapter, verse)
 
     def chapter_verse(self, chapter, verse):
         return "\\textbf{{\Large {}.{}}}~".format(chapter, verse)

--- a/backends.py
+++ b/backends.py
@@ -37,7 +37,8 @@ class LaTeX:
 \\textbf{{\Large {}.{}.{}}}~""".format(book, chapter, verse)
 
     def chapter_verse(self, chapter, verse):
-        return "\\textbf{{\Large {}.{}}}~".format(chapter, verse)
+        return """
+\\textbf{{\Large {}.{}}}~""".format(chapter, verse)
 
     def verse(self, verse):
         return "\\textbf{{{}}}~".format(verse)


### PR DESCRIPTION
Depends on PRs #18 and #19.

I had to test this using PR #17, that explicitly excludes 4 lemmas, but I expect the 4 lemmas not to affect validity of this PR.

The most delicate case is `BACKEND=LaTeX VERSES="Matthew 1:1-Revelation 22:21" LOWER_OCCURRENCE_LIMIT_TO_EXCLUDE=190` because it attempts to build the whole NT but excludes only "a few" lemmas. So if need be 190 may be reduced to e.g. 180.
