### PR TITLE
Update to backward compatible PyYAML version and fix loader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyYAML==3.12
+PyYAML==6.0
 pyuca==1.1.2
 py-sblgnt==0.5

--- a/utils.py
+++ b/utils.py
@@ -98,7 +98,7 @@ def load_yaml(filename, wrapper=lambda key, metadata: metadata):
     with open(filename) as f:
         return {
             key: wrapper(key, metadata)
-            for key, metadata in (yaml.load(f) or {}).items()
+            for key, metadata in (yaml.load(f, Loader=yaml.FullLoader) or {}).items()
         }
 
 


### PR DESCRIPTION
I've confirmed this works after pip installing requirements in a virtual env, and I was able to generate glosses for a specific passage. 👍