### PR TITLE
Update to python 3.11

### DIFF
--- a/backends.py
+++ b/backends.py
@@ -21,7 +21,7 @@ class LaTeX:
 \\setotherlanguage{{{language}}}
 
 \\setromanfont{{{typeface}}}
-
+\\newfontfamily\greekfont[Script=Greek]{{{typeface}}}
 \\linespread{{1.5}}
 \\onehalfspacing
 

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,10 @@
 import importlib
 import re
 import sys
+
 import yaml
-
-from pyuca import Collator
-
 from pysblgnt import morphgnt_rows
+from pyuca import Collator
 
 collator = Collator()
 
@@ -98,7 +97,7 @@ def load_yaml(filename, wrapper=lambda key, metadata: metadata):
     with open(filename) as f:
         return {
             key: wrapper(key, metadata)
-            for key, metadata in (yaml.load(f) or {}).items()
+            for key, metadata in (yaml.load(f, Loader=yaml.Loader) or {}).items()
         }
 
 


### PR DESCRIPTION
@jtauber 

Attached is a small PR to update the reader to what's required in Python 3.11 (the parameters to yaml load changed). 

Also, I added one line to the LaTeX backend to assure LaTeX that the font being used does, in fact, support Greek. I don't have the font you used in the example, and LaTeX was sad about using Times New Roman or Menlo (which do have Greek support, at least now; I don't know about earlier).